### PR TITLE
Check config bodyparts against csv

### DIFF
--- a/samtools.py
+++ b/samtools.py
@@ -136,10 +136,10 @@ def load_project(working_dir=os.getcwd(), threshold=0.1):
 
         if dlc_yaml['bodyparts'] == default_bodyparts:
             dlc_yaml['bodyparts'] = get_bodyparts_from_xma(os.path.join(working_dir, 'trainingdata', trial_name))
-        
+
         elif dlc_yaml['bodyparts'] != get_bodyparts_from_xma(os.path.join(working_dir, 'trainingdata', trial_name)):
             raise SyntaxError('XMAlab CSV marker names are different than DLC bodyparts.')
-    
+
     with open(project['path_config_file'], 'w') as dlc_config:
         yaml.dump(dlc_yaml, dlc_config)
 
@@ -343,7 +343,7 @@ def get_bodyparts_from_xma(path_to_trial):
     csv_path = [file for file in os.listdir(path_to_trial) if file[-4:] == '.csv']
     if len(csv_path) > 1:
         raise FileExistsError('Found more than 1 CSV file for trial: ' + path_to_trial)
-    elif len(csv_path) <= 0:
+    if len(csv_path) <= 0:
         raise FileNotFoundError('Couldn\'t find a CSV file for trial: ' + path_to_trial)
     trial_csv = pd.read_csv(path_to_trial + '/' + csv_path[0], sep=',',header=0, dtype='float',na_values='NaN')
     names = trial_csv.columns.values

--- a/test_samtools.py
+++ b/test_samtools.py
@@ -99,9 +99,8 @@ class TestConfigDefaults(unittest.TestCase):
         yaml = YAML()
 
         # Modify the number of frames (similar to how a user would)
-        config = open(os.path.join(self.working_dir, 'project_config.yaml'), 'r')
-        tmp = yaml.load(config)
-        config.close()
+        with open(os.path.join(self.working_dir, 'project_config.yaml'), 'r') as config:
+            tmp = yaml.load(config)
         tmp['nframes'] = 2
         with open(os.path.join(self.working_dir, 'project_config.yaml'), 'w') as fp:
             yaml.dump(tmp, fp)
@@ -116,9 +115,8 @@ class TestConfigDefaults(unittest.TestCase):
         yaml = YAML()
 
         sam.load_project(self.working_dir)
-        config = open(os.path.join(self.working_dir, 'project_config.yaml'), 'r')
-        tmp = yaml.load(config)
-        config.close()
+        with open(os.path.join(self.working_dir, 'project_config.yaml'), 'r') as config:
+            tmp = yaml.load(config)
 
         self.assertEqual(tmp['nframes'], 1, msg=f"Actual nframes: {tmp['nframes']}")
 
@@ -132,7 +130,7 @@ class TestConfigDefaults(unittest.TestCase):
         for _ in range(100):
             df.loc[len(df) + 1, :] = 0
 
-        df.to_csv('tmp/trainingdata/dummy/dummy.csv')
+        df.to_csv('tmp/trainingdata/dummy/dummy.csv', index=False)
 
         # Check that the user is warned
         with self.assertWarns(UserWarning):
@@ -146,9 +144,8 @@ class TestConfigDefaults(unittest.TestCase):
         sam.load_project(self.working_dir)
         path_to_config = '/tmp-NA-' + date + '/config.yaml'
 
-        dlc_config = open(self.working_dir + path_to_config)
-        config_obj = yaml.load(dlc_config)
-        dlc_config.close()
+        with open(self.working_dir + path_to_config) as dlc_config:
+            config_obj = yaml.load(dlc_config)
 
         self.assertEqual(config_obj['bodyparts'], ['foo', 'bar', 'baz'])
 
@@ -160,12 +157,12 @@ class TestConfigDefaults(unittest.TestCase):
 
         with open(self.working_dir + path_to_config, 'r') as dlc_config:
             config_dlc = yaml.load(dlc_config)
-        
+
         config_dlc['bodyparts'] = ['foo', 'bar']
-        
+
         with open(self.working_dir + path_to_config, 'w') as dlc_config:
             yaml.dump(config_dlc, dlc_config)
-        
+
         with self.assertRaises(SyntaxError):
             sam.load_project(self.working_dir)
 


### PR DESCRIPTION
Programmatically check and error if the dlc YAML bodyparts are different from the XMAlab CSV marker names